### PR TITLE
Fixing the Get Templates by user API to send array instead of object

### DIFF
--- a/apiModel/dataTemplateHandler.go
+++ b/apiModel/dataTemplateHandler.go
@@ -148,7 +148,7 @@ func GetTemplateByUser(w http.ResponseWriter, r *http.Request) {
 			commonResponse.NotFound(w, "No record found for the given query.")
 			return
 		} else {
-			commonResponse.SuccessStatus[map[string]interface{}](w, result)
+			commonResponse.SuccessStatus[[]map[string]interface{}](w, result)
 		}
 	}
 

--- a/businessFacade/DataTemplate.go
+++ b/businessFacade/DataTemplate.go
@@ -20,6 +20,6 @@ func GetLastTemplatesByPlotID(plotID string) (map[string]interface{}, error) {
 	return dataTemplateRepository.GetLastTemplateByPlotID(plotID)
 }
 
-func GetTemplatesByUser(userID string) (map[string]interface{}, error) {
+func GetTemplatesByUser(userID string) ([]map[string]interface{}, error) {
 	return dataTemplateRepository.GetTemplateByUser(userID)
 }


### PR DESCRIPTION
Fixing the Get Templates by user API to send array instead of object